### PR TITLE
Fix incoming method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - rvm 2.1.1
+
+install:
+  - bundle
+
+addons:
+  postgresql: "9.4"
+
+before_script:
+  - RAILS_ENV=test rake db:create db:migrate
+  - rake test
+

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,21 +1,20 @@
 class NotificationsController < ApplicationController
-
   # Receive incoming SMS
   def incoming
     # Grab the phone number from incoming Twilio params
-    @phone_number = params[:From]
+    phone_number = params[:From]
 
     # Find the subscriber associated with this number or create a new one
-    @new_subscriber = Subscriber.exists?(:phone_number => @phone_number) === false
-    @subscriber = Subscriber.first_or_create(:phone_number => @phone_number)
+    subscriber_exists = Subscriber.exists?(phone_number: phone_number)
+    subscriber = Subscriber.find_or_create_by(phone_number: phone_number)
 
-    @body = if params[:Body].nil? then '' else params[:Body].downcase end
     begin
-      if @new_subscriber
-        output = "Thanks for contacting TWBC! Text 'subscribe' if you would to receive updates via text message."
+      if subscriber_exists
+        # Process the command from our subscriber
+        body = params.fetch(:Body, '').downcase
+        output = process_message(body, subscriber)
       else
-        # Process the command from our Subscriber
-        output = process_message(@body, @subscriber)
+        output = "Thanks for contacting TWBC! Text 'subscribe' if you would to receive updates via text message."
       end
     rescue
       output = "Something went wrong. Try again."
@@ -45,35 +44,34 @@ class NotificationsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
+  # Use callbacks to share common setup or constraints between actions.
 
-    # Process incoming SMS
-    def process_message(message, subscriber)
-      if message == 'subscribe' || message == 'unsubscribe'
-        # If the user has subscribed flip the bit
-        # and let them know
-        subscribed = message === 'subscribe'
-        subscriber.update :subscribed => subscribed
+  # Process incoming SMS
+  def process_message(message, subscriber)
+    if message == 'subscribe' || message == 'unsubscribe'
+      # If the user has subscribed flip the bit
+      # and let them know
+      subscribed = message == 'subscribe'
+      subscriber.update subscribed: subscribed
 
-        # Respond appropriately
-        output = "You are now subscribed for updates."
-        if !subscriber.subscribed
-          output = "You have unsubscribed from notifications. Test 'subscribe' to start receieving updates again"
-        end
-      else
-        # If we don't recognize the command, text back with the list of
-        # available commands
-        output = "Sorry, we don't recognize that command. Available commands are: 'subscribe' or 'unsubscribe'."
+      # Respond appropriately
+      output = "You are now subscribed for updates."
+      if !subscriber.subscribed
+        output = "You have unsubscribed from notifications. Test 'subscribe' to start receieving updates again"
       end
-      return output
+    else
+      # If we don't recognize the command, text back with the list of
+      # available commands
+      output = "Sorry, we don't recognize that command. Available commands are: 'subscribe' or 'unsubscribe'."
     end
+    return output
+  end
 
-    # Send an SMS back to the Subscriber
-    def respond(message)
-      response = Twilio::TwiML::Response.new do |r|
-        r.Message message
-      end
-      render text: response.text
+  # Send an SMS back to the Subscriber
+  def respond(message)
+    response = Twilio::TwiML::Response.new do |r|
+      r.Message message
     end
-
+    render text: response.text
+  end
 end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,14 +1,40 @@
 require 'test_helper'
 
 class NotificationsControllerTest < ActionController::TestCase
-  test "should get receiver" do
-    get :receiver
+  # From fixtures there are 2 numbers in the database 555-5555, 555-5556
+
+  test 'when subscriber does not exist then response should contains thanks message' do
+    get :incoming, From: '555-5581'
     assert_response :success
+    assert_contains("Thanks", xpath_content(response, '//Response//Message'))
   end
 
-  test "should get sender" do
-    get :sender
+  test 'when subscriber exist then response should contains sorry message' do
+    get :incoming, From: '555-5555'
     assert_response :success
+    assert_contains("Sorry", xpath_content(response, '//Response//Message'))
   end
 
+  test 'when subscriber exist and request contains subscribe then response should contains subscribed message' do
+    get :incoming, From: '555-5555', Body: 'subscribe'
+    assert_response :success
+    assert_contains("subscribed", xpath_content(response, '//Response//Message'))
+  end
+
+  test 'when subscriber exist and request contains unsubscribe then response should contains unsubscribed message' do
+    get :incoming, From: '555-5555', Body: 'unsubscribe'
+    assert_response :success
+    assert_contains("unsubscribed", xpath_content(response, '//Response//Message'))
+  end
+
+  private
+
+  def assert_contains(expected_substring, string, *args)
+    assert_match expected_substring, string, *args
+  end
+
+  def xpath_content(response, xpath)
+    xml = Nokogiri::XML(response.body)
+    xml.at_xpath(xpath).content
+  end
 end

--- a/test/fixtures/subscribers.yml
+++ b/test/fixtures/subscribers.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  phone_number: MyString
+bob:
+  phone_number: 555-5555
 
-two:
-  phone_number: MyString
+alice:
+  phone_number: 555-5556


### PR DESCRIPTION
@jarodreyes I found a couple of issues at `NotificationsController#incoming`, this PR is solving them. 

Here is a summary of the changes made:

1. Remove unnecessary instance variables.
2. `ActiveRecord::Base#exists?` return a boolean, so I removed the comparison.
3. Use `find_or_create_by` instead of  [`first_or_create`](http://apidock.com/rails/v3.2.13/ActiveRecord/Relation/first_or_create), since first or create operates over a collection of Active Records.
4. Minor changes on implementation.
5. Removed broken test cases.
6. Add test cases for the refactored method.

We can improve this controller by pulling out the logic to create the output message in a new class, let's say `MessagesCreator`, which takes the `params` and returns the message. The action method will be significantly smaller like:

```ruby
def incoming
  message = MessageCreator.create(params)
  respond(message)
end
```

I'd love to hear your thoughts about this.
